### PR TITLE
Changed the Chrome Extension Title

### DIFF
--- a/client/chrome-ext/manifest.json
+++ b/client/chrome-ext/manifest.json
@@ -9,7 +9,7 @@
   "browser_action": {
     "default_icon": "/images/icon.png",
     "default_popup": "/core/popup.html",
-    "default_title": "test"
+    "default_title": "Geekmarks"
   },
   "background": {
     "scripts": [


### PR DESCRIPTION
I really loved this extension and have been using it for the past week.
A few months ago, even I had a similar urge to create a [bookmarking service](https://github.com/kshitij10496/Read-Later) but I couldn't get it off the ground due to lack of enough motivation. 
But I find Geekmarks suitable to what I wanted (if not better). Hence, I am excited about working on it.

Recently, I noticed that while hovering over the extension icon, it displays some default text `test`. In this PR, I have changed it to `Geekmarks` which seems to be an apt title for the extension. 
